### PR TITLE
Populate basic auth header pre-401-challenge.

### DIFF
--- a/CCMenu/Classes/CCMConnection.h
+++ b/CCMenu/Classes/CCMConnection.h
@@ -21,9 +21,10 @@
 
 // subclasses only
 
+- (BOOL)setUpCredential;
 - (void)setUpForNewRequest;
 - (void)cleanUpAfterRequest;
-
+- (void)prepareRequest:(NSMutableURLRequest*)request;
 - (BOOL)shouldContinueWithServerTrust:(SecTrustRef)secTrust;
 
 - (NSString *)errorStringForError:(NSError *)error;

--- a/CCMenu/Classes/CCMConnection.m
+++ b/CCMenu/Classes/CCMConnection.m
@@ -65,9 +65,23 @@
 {
     if(nsurlConnection != nil)
         return;
+    [self setUpCredential];
     [self setUpForNewRequest];
-    NSURLRequest *request = [NSURLRequest requestWithURL:feedURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:feedURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    [self prepareRequest:request];
     nsurlConnection = [[NSURLConnection connectionWithRequest:request delegate:self] retain];
+}
+
+- (void)prepareRequest:(NSMutableURLRequest*)request {
+    if(credential)
+        [request setValue:self.authHeader forHTTPHeaderField:@"Authorization"];
+}
+
+- (NSString*)authHeader
+{
+    NSString *authStr = [NSString stringWithFormat:@"%@:%@", credential.user, credential.password];
+    NSData *authData = [authStr dataUsingEncoding:NSASCIIStringEncoding];
+    return [NSString stringWithFormat:@"Basic %@", [authData base64EncodedStringWithOptions:NSDataBase64Encoding76CharacterLineLength]];
 }
 
 - (void)cancelRequest

--- a/CCMenu/Classes/CCMSyncConnection.m
+++ b/CCMenu/Classes/CCMSyncConnection.m
@@ -30,7 +30,9 @@
 - (NSInteger)testConnection
 {
     [self setUpForNewRequest];
-    NSURLRequest *request = [NSURLRequest requestWithURL:[self feedURL] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self feedURL] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    [self prepareRequest:request];
+
     NSURLConnection *c = [[NSURLConnection connectionWithRequest:request delegate:self] retain];
     while(didFinish == NO)
         [runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
@@ -49,7 +51,10 @@
 - (NSArray *)retrieveServerStatus
 {
     [self setUpForNewRequest];
-    NSURLRequest *request = [NSURLRequest requestWithURL:[self feedURL] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    [self setUpCredential];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self feedURL] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+    [self prepareRequest:request];
+
     [NSURLConnection connectionWithRequest:request delegate:self];
     while(didFinish == NO)
         [runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];


### PR DESCRIPTION
Fixes https://github.com/erikdoe/ccmenu/issues/9 (I ran into the same issue when trying to configure Jenkins)

If a CI server doesn't 401 and instead renders empty XML (e.g. Jenkins), the basic auth headers are never set. What this commit does is pre-populates the `Authorization` header anytime credentials are available.

I didn't add tests because it's getting late, but the test suite passes with these changes in place.