### PR TITLE
Workaround to avoid escaping already encoded URL's while opening proj…

### DIFF
--- a/CCMenu/Classes/CCMStatusItemMenuController.m
+++ b/CCMenu/Classes/CCMStatusItemMenuController.m
@@ -201,9 +201,14 @@
     CCMProject *project = [sender representedObject];
 	if([[project status] webUrl] != nil)
     {
-        NSString* urlString = [[project status] webUrl];
-        urlString = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:urlString]];
+        NSString* webUrl = [[project status] webUrl];
+        
+        NSString *decodedUrl = [webUrl stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        
+        if([webUrl isEqualToString:decodedUrl])
+            webUrl = [webUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        
+        [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:webUrl]];
     }
     else
 	{

--- a/CCMenu/Classes/CCMUserNotificationHandler.m
+++ b/CCMenu/Classes/CCMUserNotificationHandler.m
@@ -75,7 +75,12 @@
     NSString *webUrl = [notification.userInfo objectForKey:@"webUrl"];
     if(webUrl != nil)
     {
-        webUrl = [webUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSString *decodedUrl = [webUrl stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        
+        if([webUrl isEqualToString:decodedUrl])
+            webUrl = [webUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        
+        [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:webUrl]];
         [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:webUrl]];
     }
 }


### PR DESCRIPTION
…ects in the browser.

Decode the URL to open. if the decoded URL is equal to the original URL, it is not encoded in the first place and we encode it before opening. 