### PR TITLE
Adding support for CloudBees hosted Jenkins server

### DIFF
--- a/CCMenu/Classes/CCMConnection.m
+++ b/CCMenu/Classes/CCMConnection.m
@@ -73,7 +73,7 @@
 - (NSURLRequest *)createRequest
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:feedURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
-    if((useHudsonJenkinsAuthWorkaround) && ((credential != nil) || [self setUpCredential]))
+    if((useHudsonJenkinsAuthWorkaround || [[feedURL host] containsString: @"cloudbees.com"]) && ((credential != nil) || [self setUpCredential]))
         [self addBasicAuthToRequest:request];
     return request;
 }


### PR DESCRIPTION
CloudBees is a hosted Jenkins server. In order to access cc.xml on this server, a usual Jenkins workaround should be applied. 

The trouble is that CloudBees front end strips Jenkins headers and returns 200 with HTML form for authorization. Thus, there are no other reliable ways to identify CloudBees Jenkins instance other than by using URL.

A viable alternative is to add a server-specific configuration parameter "Jenkins Server" that can be used to explicitly request Jenkins work-around to be applied.