### PR TITLE
Resolve issue #4 Change icon selection algorithm to match CCTray. If any …

### DIFF
--- a/CCMenu/Classes/CCMStatusItemMenuController.m
+++ b/CCMenu/Classes/CCMStatusItemMenuController.m
@@ -84,31 +84,32 @@
         [item setImage:[imageFactory imageForUnavailableServer]];
 		[item setTitle:@""];
     } 
-    else if([[project status] isBuilding] == NO)
-    {
-        [item setImage:[imageFactory imageForStatus:[project status]]];
-        NSString *text = @"";
-        if([[project status] buildDidFail])
-        {
-            __block int failCount = 0;
-            [projectList enumerateObjectsUsingBlock:^(CCMProject *project, NSUInteger idx, BOOL *stop) {
-                if([[project status] buildDidFail])
-                    failCount += 1;
-            }];
-            text = [NSString stringWithFormat:@"%u", failCount];
-        }
-        [item setFormattedTitle:text];
-    }
     else
     {
         [item setImage:[imageFactory imageForStatus:[project status]]];
         NSString *text = @"";
-        if([defaultsManager shouldShowTimerInMenu])
+            __block int failCount = 0;
+            [projectList enumerateObjectsUsingBlock:^(CCMProject *project, NSUInteger idx, BOOL *stop) {
+                if([[project status] buildDidFail]) {
+                    failCount += 1;
+                    // A failed build should take prescident for image status on menu bar.
+                    [item setImage:[imageFactory imageForStatus:[project status]]];
+                }
+            }];
+        if(failCount > 0) {
+            text = [NSString stringWithFormat:@"%u", failCount];
+        }
+        if(([[project status] isBuilding] == YES) && [defaultsManager shouldShowTimerInMenu])
         {
             NSCalendarDate *estimatedComplete = [project estimatedBuildCompleteTime];
             if(estimatedComplete != nil)
             {
-                text = [[NSCalendarDate date] descriptionOfIntervalSinceDate:estimatedComplete withSign:YES];
+                NSString *intervalSinceDateString = [[NSCalendarDate date] descriptionOfIntervalSinceDate:estimatedComplete withSign:YES];
+                if ([text length] > 0) {
+                    text = [NSString stringWithFormat: @"%@ %@", text, intervalSinceDateString];
+                } else {
+                    text = intervalSinceDateString;
+                }
             }
         }
         [item setFormattedTitle:text];

--- a/CCMenuTests/Classes/CCMStatusItemMenuControllerTest.m
+++ b/CCMenuTests/Classes/CCMStatusItemMenuControllerTest.m
@@ -294,8 +294,8 @@
 - (void)testDisplaysBuildingWhenAtLeastOneProjectIsBuilding
 {
     CCMProject *p1 = [self createProjectWithActivity:@"Building" lastBuildStatus:@"Success"];
-    CCMProject *p2 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Failure"];
-    CCMProject *p3 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Failure"];
+    CCMProject *p2 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Success"];
+    CCMProject *p3 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Success"];
     NSArray *const projects = @[p1, p2, p3];
     OCMStub([serverMonitorMock projects]).andReturn(projects);
     OCMStub([imageFactoryMock imageForStatus:[p1 status]]).andReturn(dummyImage);
@@ -306,7 +306,22 @@
     OCMVerify([statusItemMock setFormattedTitle:@""]);
 }
 
-- (void)testDisplaysFixingWhenAtLeastOneProjectWithLastStatusFailedIsBuilding
+- (void)testDisplaysFailedWhenAtLeastOneProjectIsBuildingAndAnotherFailed
+{
+    CCMProject *p1 = [self createProjectWithActivity:@"Building" lastBuildStatus:@"Success"];
+    CCMProject *p2 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Failure"];
+    CCMProject *p3 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Success"];
+    NSArray *const projects = @[p1, p2, p3];
+    OCMStub([serverMonitorMock projects]).andReturn(projects);
+    OCMStub([imageFactoryMock imageForStatus:[p1 status]]).andReturn(dummyImage);
+    
+    [controller displayProjects:nil];
+    
+    OCMVerify([statusItemMock setImage:dummyImage]);
+    OCMVerify([statusItemMock setFormattedTitle:@"1"]);
+}
+
+- (void)testDisplaysFailureWhenAtLeastOneProjectWithLastStatusFailedIsBuilding
 {
     CCMProject *p1 = [self createProjectWithActivity:@"Building" lastBuildStatus:@"Success"];
     CCMProject *p2 = [self createProjectWithActivity:@"Sleeping" lastBuildStatus:@"Failure"];
@@ -318,7 +333,7 @@
 	[controller displayProjects:nil];
 	
     OCMVerify([statusItemMock setImage:dummyImage]);
-    OCMVerify([statusItemMock setFormattedTitle:@""]);
+    OCMVerify([statusItemMock setFormattedTitle:@"2"]);
 }
 
 - (void)testDoesNotDisplayBuildingTimerWhenDefaultIsOff
@@ -375,7 +390,7 @@
 
 	[controller displayProjects:nil];
 	
-    OCMVerify([statusItemMock setFormattedTitle:startsWith(@"-1:")]);
+    OCMVerify([statusItemMock setFormattedTitle:startsWith(@"1 -1:")]);
 }
 
 @end


### PR DESCRIPTION
…build in the project list fails then the Status Item icon should be the build fail icon. A project in 'building' status will no longer change the icon from failed to 'building'.
