### PR TITLE
Always send (basic) auth, even if not being challenged to do so.

### DIFF
--- a/CCMenu/Classes/CCMConnection.m
+++ b/CCMenu/Classes/CCMConnection.m
@@ -73,7 +73,8 @@
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:feedURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
     BOOL isInCloudbeesDomain = ([feedURL host] != nil) && ([[feedURL host] rangeOfString:@"cloudbees.com"].location != NSNotFound);
-    if((useHudsonJenkinsAuthWorkaround || isInCloudbeesDomain) && ((credential != nil) || [self setUpCredential]))
+	BOOL needsAuth = isInCloudbeesDomain || YES;
+    if((useHudsonJenkinsAuthWorkaround || needsAuth) && ((credential != nil) || [self setUpCredential]))
         [self addBasicAuthToRequest:request];
     return request;
 }


### PR DESCRIPTION
Jenkins can be configured to be both public and private, exposing private projects only
if proper auth credentials are being passed during fetch of cc.xml.

If no auth is provided, private projects aren't included in cc.xml and hence cannot be added as projects to CCMenu.

For security reasons one might wish to narrow this down to when using HTTPS as scheme, only.