### PR TITLE
Add make run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,9 @@ clean:
 test:
 	@echo "Running OS X tests..."
 	$(XCODEBUILD) $(MACOSX) test | xcpretty -c
+
+run: test
+	open build/Debug/CCMenu.app
+
+
+


### PR DESCRIPTION
Enables developers to start CCMenu using `make run`, which also builds and test the product if needed.