### PR TITLE
Using NSValueTransformer to provide NSAttributedStrings for controls …

### DIFF
--- a/CCMenu/Classes/CCMProjectDefaultValueTransformer.h
+++ b/CCMenu/Classes/CCMProjectDefaultValueTransformer.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @interface CCMProjectDefaultValueTransformer : NSValueTransformer
-
+- (id)transformedValue:(id)value isSelected:(BOOL)isSelected;
 @end
 
 extern NSString *CCMProjectDefaultValueTransformerName;

--- a/CCMenu/Classes/CCMProjectDefaultValueTransformer.m
+++ b/CCMenu/Classes/CCMProjectDefaultValueTransformer.m
@@ -18,17 +18,25 @@ NSString *CCMProjectDefaultValueTransformerName = @"CCMProjectDefaultValueTransf
 
 - (id)transformedValue:(id)value
 {
+	return [self transformedValue:value isSelected:NO];
+}
+
+- (id)transformedValue:(id)value isSelected:(BOOL)isSelected
+{
     if(value == nil)
         return nil;
-    
-    NSString *name = [value objectForKey:@"projectName"];
+
+	NSString *name = [value objectForKey:@"projectName"];
     NSString *displayName = [value objectForKey:@"displayName"];
     if(displayName != nil)
         name = [NSString stringWithFormat:@"%@ (%@)", name, displayName];
-    NSDictionary *nameAttrs = @{NSFontAttributeName: [NSFont boldSystemFontOfSize:[NSFont systemFontSizeForControlSize:NSRegularControlSize]]};
+	NSColor *nameColor = isSelected ? [NSColor alternateSelectedControlTextColor] : [NSColor controlTextColor];
+    NSDictionary *nameAttrs = @{NSFontAttributeName: [NSFont boldSystemFontOfSize:[NSFont systemFontSizeForControlSize:NSRegularControlSize]],
+								NSForegroundColorAttributeName: nameColor};
     NSString *url = [value objectForKey:@"serverUrl"];
+	NSColor *urlColor = isSelected ? [NSColor selectedTextColor] : [NSColor disabledControlTextColor];
     NSDictionary *urlAttrs = @{ NSFontAttributeName: [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:NSSmallControlSize]],
-                                NSForegroundColorAttributeName: [NSColor disabledControlTextColor]};
+                                NSForegroundColorAttributeName: urlColor};
 
     NSMutableAttributedString *result = [[[NSMutableAttributedString alloc] init] autorelease];
     [result appendAttributedString:[[[NSAttributedString alloc] initWithString:name attributes:nameAttrs] autorelease]];

--- a/CCMenu/Classes/CCMReorderableArrayController.m
+++ b/CCMenu/Classes/CCMReorderableArrayController.m
@@ -1,6 +1,7 @@
 
 #import "CCMReorderableArrayController.h"
 #import "CCMPreferencesController.h"
+#import "CCMProjectDefaultValueTransformer.h"
 
 /* Implementation based on mmalc's DNDArrayController, which was originally available at
    http://homepage.mac.com/mmalc/CocoaExamples/controllers.html
@@ -8,6 +9,24 @@
 
 
 NSString *CCMDraggedRowType = @"net.sourceforge.cruisecontrol.CCMenu.DraggedRowType";
+
+
+@interface CCMTableCellView : NSTableCellView
+@end
+
+@implementation CCMTableCellView
+
+- (void)drawRect:(NSRect)dirtyRect {
+	BOOL isSelected = [(NSTableRowView *)[self superview] isSelected];
+
+	CCMProjectDefaultValueTransformer *transformer = (CCMProjectDefaultValueTransformer *)[CCMProjectDefaultValueTransformer valueTransformerForName:CCMProjectDefaultValueTransformerName];
+	NSAttributedString *s = [transformer transformedValue:self.objectValue isSelected:isSelected];
+	[[self textField] setAttributedStringValue:s];
+
+	[super drawRect:dirtyRect];
+}
+
+@end
 
 
 @implementation CCMReorderableArrayController

--- a/CCMenu/en.lproj/Preferences.xib
+++ b/CCMenu/en.lproj/Preferences.xib
@@ -75,7 +75,7 @@
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
-                                            <tableCellView id="eKa-3E-1Fc">
+                                            <tableCellView id="eKa-3E-1Fc" customClass="CCMTableCellView">
                                                 <rect key="frame" x="1" y="1" width="305" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>


### PR DESCRIPTION
…isn't as clever as it sounds

CCMProjectDefaultValueTransformer provides an NSAttributedString for displaying cells/rows in the "projects" table view within preferences. However, highlighting the (view based) cells has no effect on the displayed text, as the value transformer doesn't have any relation to the context the text will be displayed in. Highlighting cells thus doesn't lead to changing the text attributes in a sensible way.

This hack provides a way for the value transformer to create a proper attributed string.