### PR TITLE
Update copyright

### DIFF
--- a/CCMenu/en.lproj/About.xib
+++ b/CCMenu/en.lproj/About.xib
@@ -62,7 +62,7 @@
                             <font key="font" metaFont="smallSystem"/>
                             <string key="title">Development: Erik Dörnenburg. Contributions: Luke Barrett, Marcus Müller, David Pattinson, Fabian Vogler
 
-Copyright © 2007-2017 ThoughtWorks, Inc.</string>
+Copyright © 2007–2018 ThoughtWorks, Inc.</string>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>


### PR DESCRIPTION
This updates the copyright to the current year. I also replaced the `HYPHEN-MINUS` character with an `EN DASH` character, which is more appropriate for numerical ranges.